### PR TITLE
Fix: pass in empty string when yesno field doesn't have label. add test

### DIFF
--- a/linter/rules/yesno_field_label_should_not_contain_yesno.py
+++ b/linter/rules/yesno_field_label_should_not_contain_yesno.py
@@ -9,5 +9,5 @@ class YesnoFieldLabelShouldNotContainYesno(Rule):
 
     def run(self, field: Any) -> bool:
         if field.get('type') == 'yesno':
-            return not search(r'(yes[_/ ]*no)', field.get('label'), IGNORECASE)
+            return not search(r'(yes[_/ ]*no)', field.get('label', ''), IGNORECASE)
         return True

--- a/test/rules/test_yesno_field_label_should_not_contain_yesno.py
+++ b/test/rules/test_yesno_field_label_should_not_contain_yesno.py
@@ -11,6 +11,14 @@ def test_run_method_successfully_validates_yesno_label_does_not_contain_yesno() 
     assert rule_result == True
 
 
+def test_run_method_succeeds_when_yesno_has_no_label() -> None:
+    rule = YesnoFieldLabelShouldNotContainYesno(Severity.ERROR.value)
+
+    field = {'name': 'is_valid', 'type': 'yesno'}
+    rule_result = rule.run(field)
+    assert rule_result == True
+
+
 def test_run_method_fails_when_yesno_label_contains_yesno() -> None:
     rule = YesnoFieldLabelShouldNotContainYesno(Severity.ERROR.value)
 


### PR DESCRIPTION
Updating yesno_field_label_should_not_contain_yesno rule to pass in an empty string when the field has no label. Received the below error when setting up the linter:

```
File "/linter/lookml_linter.py", line 64, in __lint_object
    success = runner.run(object)
  File "/linter/rules/yesno_field_label_should_not_contain_yesno.py", line 12, in run
    return not search(r'(yes[_/ ]*no)', field.get('label'), IGNORECASE)
  File "/usr/local/lib/python3.8/re.py", line 201, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object
```